### PR TITLE
feat: create secret for sdk connection

### DIFF
--- a/api/v1/casdoor_types.go
+++ b/api/v1/casdoor_types.go
@@ -59,6 +59,10 @@ type CasdoorStatus struct {
 
 	// reason if pending or failed
 	Reason string `json:"reason,omitempty"`
+
+	// ConnectionConfig  secret name of Casdoor SDK configuration to connect
+	// TODO: multiple applications
+	ConnectionConfig string `json:"connectionConfig,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/operator.casdoor.org_casdoors.yaml
+++ b/config/crd/bases/operator.casdoor.org_casdoors.yaml
@@ -348,6 +348,10 @@ spec:
           status:
             description: CasdoorStatus defines the observed state of Casdoor
             properties:
+              connectionConfig:
+                description: 'ConnectionConfig  secret name of Casdoor SDK configuration
+                  to connect TODO: multiple applications'
+                type: string
               reason:
                 description: reason if pending or failed
                 type: string


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34068205/204095632-73218728-ca99-4e90-afbb-873aa88b8cfe.png)
Users can query the secret named the same with `connectionConfig`. Then, they can use the secret to configure Casdoor SDK and connect Casdoor.